### PR TITLE
Some README.md edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ docpad install restapi inlinegui
 Output the elements that you want to edit:
 
 ```
-<%- @editable(item: @document, property: 'title', element: 'h1') %>
-<%- @editable(item: @document, property: 'content', value: @content) %>
+<%- @editable(item: @document, attribute: 'title', element: 'h1') %>
+<%- @editable(item: @document, attribute: 'content', value: @content) %>
 ```
 
 Edit them by accessing `/inlinegui/` on your server.


### PR DESCRIPTION
Just some things I noticed when attempting to try out the InlineGUI plugin in my project.
1. Changed the 'property' options in the Eco template snippet to 'attribute' options, as you yourself have in the Inline GUI skeleton you're making.  This allows the rendered divs to produce 'property' attributes without "undefined" when using Jade and text-plugin to render Eco.  If "property" works in straight Eco then ignore this.
2. Maybe I'm using InlineGUI wrong but going to localhost:9778/inlinegui never works for me, I always get "Not Found" and that's it.

This is my first ever pull request for GitHub, if I'm out of line or doing this completely wrong please let me know!
